### PR TITLE
Makes CachePot.getInstance() truly thread-safe

### DIFF
--- a/library/src/main/java/com/github/kimkevin/cachepot/CachePot.java
+++ b/library/src/main/java/com/github/kimkevin/cachepot/CachePot.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CachePot {
-  private static CachePot instance;
+  private static volatile CachePot instance;
 
   public static CachePot getInstance() {
     if (instance == null) {


### PR DESCRIPTION
Details can be found here: [Double-checked_locking](https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java)